### PR TITLE
Fix null pointer 1.27

### DIFF
--- a/safezone.c
+++ b/safezone.c
@@ -3,7 +3,8 @@ class SafeZone_PlugIn
 	protected bool Activate_SafeZone_PlugIn = true; // safezone on (true) or off (false)
 	protected float SAFEZONE_time_repeat_checking = 10; //In seconds
 	
-	ref static TStringArray SAFEZONE_LOACTIONS = {"6974.876465 388.432281 11345.492188"};//Map coords (positions of the safe zone)
+	// "6307.81 2000 9511.72"
+	ref static TStringArray SAFEZONE_LOCATIONS = {"6974.876465 388.432281 11345.492188"};//Map coords (positions of the safe zone)
 	protected static float  SAFEZONE_RADIUS   = 800; //In meter
 	protected static string SAFEZONE_ENTRY_MESSAGE     = "You are in the safezone you canot be harmed";
 	protected static string SAFEZONE_EXIT_MESSAGE      = "You left the safezone you can now be harmed";
@@ -21,11 +22,11 @@ class SafeZone_PlugIn
 	{
 		private array<Man> players = new array<Man>;
 		GetGame().GetPlayers( players );
-		if (SAFEZONE_LOACTIONS.Count() > 0)
+		if (SAFEZONE_LOCATIONS.Count() > 0)
 		{
 			if (players.Count() > 0)
 			{
-				foreach(string SAFEZONE_LOACTION: SAFEZONE_LOACTIONS)
+				foreach(string SAFEZONE_LOCATION: SAFEZONE_LOCATIONS)
 				{
 					if( players.Count() > 0 )
 					{
@@ -34,7 +35,7 @@ class SafeZone_PlugIn
 							if(player)
 							{
 								private PlayerBase player_casted = PlayerBase.Cast(player);
-								CheckingPosition(player_casted,SAFEZONE_LOACTION.ToVector());
+								CheckingPosition(player_casted,SAFEZONE_LOCATION.ToVector());
 							}
 						}
 				   }
@@ -43,7 +44,7 @@ class SafeZone_PlugIn
 		}
 	}
 
-	static void CheckingPosition(PlayerBase player,vector SAFEZONE_LOACTION)
+	static void CheckingPosition(PlayerBase player,vector SAFEZONE_LOCATION)
 	{
 		private float SAFEZONE_distance;
 		private string SAFEZONE_ZoneCheck, SAFEZONE_UID_PLAYER, SAFEZONE_NAME_PLAYER;
@@ -51,8 +52,8 @@ class SafeZone_PlugIn
 		SAFEZONE_UID_PLAYER = player.GetIdentity().GetPlainId(); //Steam 64	
 
 		private vector SAFEZONE_pos_player = player.GetPosition();
-		private vector SAFEZONE_LOCATION_FIXED = CorrectToGroundPosY(SAFEZONE_LOACTION);
-		private string name_mesage_profile = "GodModeEnabledFor: " + SAFEZONE_UID_PLAYER + " Location: " + SAFEZONE_LOACTION.ToString();
+		private vector SAFEZONE_LOCATION_FIXED = CorrectToGroundPosY(SAFEZONE_LOCATION);
+		private string name_mesage_profile = "GodModeEnabledFor: " + SAFEZONE_UID_PLAYER + " Location: " + SAFEZONE_LOCATION.ToString();
 		SAFEZONE_distance = vector.Distance(SAFEZONE_pos_player,SAFEZONE_LOCATION_FIXED);
 		if (SAFEZONE_distance <= SAFEZONE_RADIUS) //Player Inside Zone
 		{

--- a/safezone.c
+++ b/safezone.c
@@ -4,8 +4,8 @@ class SafeZone_PlugIn
 	protected float SAFEZONE_time_repeat_checking = 10; //In seconds
 	
 	// "6307.81 2000 9511.72"
-	ref static TStringArray SAFEZONE_LOCATIONS = {"6974.876465 388.432281 11345.492188"};//Map coords (positions of the safe zone)
 	protected static float  SAFEZONE_RADIUS   = 800; //In meter
+	ref static TStringArray SAFEZONE_LOCATIONS;
 	protected static string SAFEZONE_ENTRY_MESSAGE     = "You are in the safezone you canot be harmed";
 	protected static string SAFEZONE_EXIT_MESSAGE      = "You left the safezone you can now be harmed";
 		
@@ -14,6 +14,7 @@ class SafeZone_PlugIn
 	{
 		if(Activate_SafeZone_PlugIn)
 		{
+			SAFEZONE_LOCATIONS = {"6974.876465 388.432281 11345.492188"};//Map coords (positions of the safe zone)
 			GetGame().GetCallQueue(CALL_CATEGORY_GAMEPLAY).CallLater(RunCheckStart, (SAFEZONE_time_repeat_checking * 1000), true); 
 		}
 	}
@@ -121,12 +122,13 @@ class SafeZone_PlugIn
 		}
 	}
 }
-ref SafeZone_PlugIn SafeZone = new SafeZone_PlugIn();
+ref SafeZone_PlugIn SafeZone;
 modded class CustomMission
 {	
 	override void OnInit () 
     {
 		super.OnInit();
+		SafeZone = new SafeZone_PlugIn();
 		SafeZone.OnInit();		
     }
 }


### PR DESCRIPTION
script was generating exceptions on 1.27.x DayZ version:
![image](https://github.com/user-attachments/assets/cd3bd21d-b803-47c1-beee-5aceb163bb2c)

This fix will avoid these exceptions (i don't know why we need to instanciate ref variables in methods and not in glopal scope)

It work perfectly now (tested on Namalsk server 1.27.x)
![image](https://github.com/user-attachments/assets/3aa7c45a-5a19-42fb-97e7-cdeb9da32ad5)

